### PR TITLE
Fix default arguments for Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Daniel Schröder <daniel.schroeder@skriptfabrik.com>"
 
 ARG ELEMENTS_CLI_VERSION=latest
 
-ENV LISTEN_ADDRESS=0.0.0.0
-ENV HOSTNAME=localhost
+ENV ELEMENTS_HOSTNAME=0.0.0.0
 ENV NODE_ENV=production
 
 COPY . /opt/elements-cli-${ELEMENTS_CLI_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ LABEL maintainer="Daniel Schröder <daniel.schroeder@skriptfabrik.com>"
 
 ARG ELEMENTS_CLI_VERSION=latest
 
-ENV ELEMENTS_HOSTNAME=0.0.0.0
+ENV ELEMENTS_HOSTNAME=localhost
+ENV LISTEN_ADDRESS=0.0.0.0
 ENV NODE_ENV=production
 
 COPY . /opt/elements-cli-${ELEMENTS_CLI_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ LABEL maintainer="Daniel Schröder <daniel.schroeder@skriptfabrik.com>"
 
 ARG ELEMENTS_CLI_VERSION=latest
 
-ENV HOSTNAME=0.0.0.0
+ENV LISTEN_ADDRESS=0.0.0.0
+ENV HOSTNAME=localhost
 ENV NODE_ENV=production
 
 COPY . /opt/elements-cli-${ELEMENTS_CLI_VERSION}

--- a/elements-cli.js
+++ b/elements-cli.js
@@ -338,7 +338,7 @@ app.get(
 
 // Listen for HTTP connections
 
-const server = app.listen(argv.port, argv.hostname, () =>
+const server = app.listen(argv.port, process.env.LISTEN_ADDRESS || argv.hostname, () =>
   console.error(
     `Elements server listening on http://${argv.hostname}:${argv.port}${baseHref}`
   )

--- a/elements-cli.js
+++ b/elements-cli.js
@@ -18,13 +18,13 @@ const { URL } = require('url');
 // Argument defaults
 
 const argd = {
-  'base-path': process.env.BASE_PATH || '/',
-  hostname: process.env.HOSTNAME || 'localhost',
-  layout: process.env.LAYOUT || 'sidebar',
-  port: parseInt(process.env.PORT || '8000'),
-  router: process.env.ROUTER || 'history',
-  style: process.env.STYLE || 'display: block; height: 100vh',
-  title: process.env.TITLE || 'My API Docs',
+  'base-path': process.env.ELEMENTS_BASE_PATH || '/',
+  hostname: process.env.ELEMENTS_HOSTNAME || 'localhost',
+  layout: process.env.ELEMENTS_LAYOUT || 'sidebar',
+  port: parseInt(process.env.ELEMENTS_PORT || '8000'),
+  router: process.env.ELEMENTS_ROUTER || 'history',
+  style: process.env.ELEMENTS_STYLE || 'display: block; height: 100vh',
+  title: process.env.ELEMENTS_TITLE || 'My API Docs',
   'working-dir': process.cwd(),
 };
 


### PR DESCRIPTION
The Docker container should arguably always listen on 0.0.0.0 regardless of the desired advertised hostname. This makes the container work with no extra arguments and the url advertised on stdout is correct so you can click it in your console.